### PR TITLE
:bug: fix(TfWorkspaceStateUtility): correct command arguments to use the specified state file

### DIFF
--- a/tfstateutil/tf_state_util.go
+++ b/tfstateutil/tf_state_util.go
@@ -102,7 +102,7 @@ func (t *tfWorkspaceStateUtility) ListAllResourcesFromWorkspaceStateWithStateFil
 	args := []string{"state", "list"}
 	args = append(args, "-state="+stateFilePath)
 
-	cmd := exec.CommandContext(t.ctx, "terraform", "state", "list")
+	cmd := exec.CommandContext(t.ctx, "terraform", args...)
 	cmd.Dir = workingDir
 
 	// Remove TF_LOG and TF_CLI_CONFIG_FILE from the environment for this command


### PR DESCRIPTION
## Background

This pull request updates the way the `terraform state list` command is constructed in the `tfWorkspaceStateUtility` implementation. The change ensures that the command arguments are built dynamically, which improves maintainability and correctness.

Command construction update:

* In the `ListAllResourcesFromWorkspaceStateWithStateFil` method of `tfstateutil/tf_state_util.go`, the `exec.CommandContext` invocation now uses the dynamically built `args` slice instead of a hardcoded command string.

## How Has This Been Tested

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.